### PR TITLE
Minor fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpVis
 Title: Visualisation functions for harp.
-Version: 0.0.0.9060
+Version: 0.0.0.9061
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]"
   ))

--- a/R/group_selectors.R
+++ b/R/group_selectors.R
@@ -56,7 +56,7 @@ group_selectors <- function(input, output, session, verif_data) {
 
   std_ens_tables  <- grep("ens_", names(harpVis::ens_verif_data))
   std_ens_columns <- unique(unlist(lapply(harpVis::ens_verif_data[std_ens_tables], names)))
-  std_ens_columns <- c(std_ens_columns, "spread_skill_ratio", "parameter")
+  std_ens_columns <- c(std_ens_columns, "spread_skill_ratio", "parameter", "dates", "num_stations")
 
   # When there is new data get the grouping columns and remove all inserted UI
 

--- a/R/plot_scorecard.R
+++ b/R/plot_scorecard.R
@@ -110,17 +110,13 @@ plot_scorecard <- function(
     check_length(significance_breaks, legend_labels)
   }
 
-  classes <- as.numeric(
-    cut(
-      abs(sc_data[["pc_diff"]]) * sc_data[["better"]],
-      breaks = significance_breaks
-    )
+  classes <- cut(
+    abs(sc_data[["pc_diff"]]) * sc_data[["better"]],
+    breaks = significance_breaks
   )
+  names(legend_labels) <- levels(classes)
 
-  classes <- factor(classes, labels = legend_labels[sort(unique(classes))])
-  levels(classes) <- c(levels(classes), legend_labels[!legend_labels %in% levels(classes)])
-
-  sc_data[["class"]] <- classes
+  sc_data[["class"]] <- forcats::fct_relabel(classes, ~legend_labels[.x])
 
   if (grid_facets) {
     if (length(facet_by) != 2) {


### PR DESCRIPTION
This PR improves the class labeling for plot_scorecard and makes sure that "dates" and "num_stations" don't come up as group selectors in shiny_plot_point_verif() - these columns are automatically added by bind_point_verif() and thus ens_read_and_verify when more than 1 iteration is done. 