### PR TITLE
Fix stringsAsFactors issue for R < 4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpVis
 Title: Visualisation functions for harp.
-Version: 0.0.0.9061
+Version: 0.0.0.9062
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]"
   ))
@@ -39,7 +39,7 @@ Remotes:
     harphub/meteogrid
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 URL: https://github.com/harphub/harpVis
 BugReports: https://github.com/harphub/harpVis/issues
 Suggests: 

--- a/R/download_verif_plot.R
+++ b/R/download_verif_plot.R
@@ -265,7 +265,8 @@ download_verif_plot <- function(input, output, session, verif_data, score_option
 
       member_cols <- data.frame(
         member_highlight = highlight_mems,
-        colour           = all_cols
+        colour           = all_cols,
+        stringsAsFactors = FALSE
       )
 
       member_cols[["colour"]][grep("Other", member_cols[["member_highlight"]])] <- "grey70"
@@ -381,7 +382,8 @@ download_verif_plot <- function(input, output, session, verif_data, score_option
 
         member_cols <- data.frame(
           member_highlight = highlight_mems,
-          colour           = all_cols
+          colour           = all_cols,
+          stringsAsFactors = FALSE
         )
 
         member_cols[["colour"]][grep("Other", member_cols[["member_highlight"]])] <- "grey70"


### PR DESCRIPTION
Fixes #21 

From R >= 4, stringsAsFactors = FALSE as default for data frames. However, this still needs to be explicitly set for older R versions. This PR fixes a problem caused by this that resulted in ensemble members not being plotted in shiny_plot_point_verif() for R < 4 where the data frame column is treated as factors instead of strings. 