### PR TITLE
Fix shiny_plot_point_verif error throwing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harpVis
 Title: Visualisation functions for harp.
-Version: 0.0.0.9062
+Version: 0.0.0.9063
 Authors@R: as.person(c(
     "Andrew Singleton <andrewts@met.no> [aut, cre]"
   ))

--- a/R/options_bar.R
+++ b/R/options_bar.R
@@ -160,7 +160,7 @@ options_bar <- function(input, output, session) {
   shiny::observeEvent(list(input$parameter, input$dates, input$models), {
     shiny::req(input$models)
     models <- gsub(" \\+ ", ".model.", input$models)
-    regexp <- paste(paste0(input$parameter, "\\."), input$dates, models, sep = "[[:graph:]]*")
+    regexp <- paste0(paste(paste0(input$parameter, "\\."), input$dates, models, sep = "[[:graph:]]*"), ".rds")
     verif_file(file.path(data_dir(), grep(regexp, data_files$filenames, value = TRUE)))
   })
 

--- a/R/options_bar.R
+++ b/R/options_bar.R
@@ -160,7 +160,7 @@ options_bar <- function(input, output, session) {
   shiny::observeEvent(list(input$parameter, input$dates, input$models), {
     shiny::req(input$models)
     models <- gsub(" \\+ ", ".model.", input$models)
-    regexp <- paste0(paste(paste0(input$parameter, "\\."), input$dates, models, sep = "[[:graph:]]*"), ".rds")
+    regexp <- paste0(paste(paste0(input$parameter, "\\."), input$dates, models, sep = "[[:graph:]]*"), ".rds$")
     verif_file(file.path(data_dir(), grep(regexp, data_files$filenames, value = TRUE)))
   })
 


### PR DESCRIPTION
When shiny_plot_point_verif tries to to open files with a subset of models that exist for another file, the regexp would find more than one file. 

e.g. if we have

model_a + model_b + model_c

and

model_a + model_b

If the second was chosen it would find the file for both and an error would be thrown. 

This is fixed by including ".rds$" in the file name regexp