### PR TITLE
fix plot_field colouring for max and min breaks

### DIFF
--- a/R/plot_field.R
+++ b/R/plot_field.R
@@ -204,6 +204,9 @@ plot_field.geofield <- function(
     breaks <- pretty(.fcst, num_breaks)
   }
 
+  .fcst[.fcst < min(breaks)] <- min(breaks)
+  .fcst[.fcst > max(breaks)] <- max(breaks)
+
   plot_colours <- colorRampPalette(palette)(length(breaks) - 1)
 
   if (title == "auto") {


### PR DESCRIPTION
Before this fix, plot_field would set colour to na.colot for values outside of the breaks. In general this is undesirable - especially for difference plots when na.color is white or transparent, whereby large differences might appear to be no difference at all. 