### PR TITLE
Some harpVis bugfixes based on UWC-W rds

### DIFF
--- a/R/dashboard_point_verif.R
+++ b/R/dashboard_point_verif.R
@@ -306,6 +306,8 @@ dashboard_point_verif <- function(
         )
 
         times <- unique(thresh_data_to_plot()[[thresh_table()]][[time_var]])
+        times <- times[!times %in% "All"]
+        if (length(times) > 0) {
         times <- parse_times(times, time_var)
         shiny::insertUI(
           selector = paste0("#", ns("thresh_selectors")),
@@ -320,6 +322,7 @@ dashboard_point_verif <- function(
               )
           #)
         )
+        }
       }
 
     }
@@ -380,7 +383,9 @@ dashboard_point_verif <- function(
         plot_data <- plot_data_thresh
       }
 
-      if (nrow(plot_data[[thresh_table()]]) < 1) {
+      tavals <- unique(plot_data[[thresh_table()]][[time_axis()]])
+      tavals <- tavals[!tavals %in% "All"]
+      if ( (nrow(plot_data[[thresh_table()]]) < 1) || (length(tavals) < 1)) {
         dashboard_plots[[paste0("thresh_", i)]] <- NULL
       } else {
         dashboard_plots[[paste0("thresh_", i)]] <- harpVis::plot_point_verif(

--- a/R/download_verif_plot.R
+++ b/R/download_verif_plot.R
@@ -390,7 +390,8 @@ download_verif_plot <- function(input, output, session, verif_data, score_option
           )
         group_data <- filter_for_x(
           group_data, score_options()$x_axis,
-          flip_axes = score_options()$flip_axes
+          flip_axes = score_options()$flip_axes,
+          facet_vars = score_options()$facets
         )
         score_plot <- score_plot +
           ggplot2::geom_line(data  = group_data, colour = group_colour, size = 1.1) +
@@ -532,7 +533,8 @@ download_verif_plot <- function(input, output, session, verif_data, score_option
             )
           group_data <- filter_for_x(
             group_data, score_options()$x_axis,
-            flip_axes = score_options()$flip_axes
+            flip_axes = score_options()$flip_axes,
+            facet_vars = score_options()$facets
           )
           score_plot <- score_plot +
             ggplot2::geom_line(data  = group_data, colour = group_colour, size = 1.1) +

--- a/R/interactive_point_verif.R
+++ b/R/interactive_point_verif.R
@@ -1180,7 +1180,8 @@ interactive_point_verif <- function(
           )
         group_data <- filter_for_x(
           group_data, score_options()$x_axis,
-          flip_axes = score_options()$flip_axes
+          flip_axes = score_options()$flip_axes,
+          facet_vars = score_options()$facets
         )
         score_plot <- score_plot +
           ggplot2::geom_line(data  = group_data, colour = group_colour, size = 1.1) +


### PR DESCRIPTION
- Add facet_vars to filter_for_x when generating member bias plots.
- Only plot threshold scores in the dashboard when there is a valid x axis. This can arise e.g. if lead_time and valid_dttm are grouping variables for the summary scores but only lead_time is used for threshold scores. 