### PR TITLE
Various additions to the harpSpatial vis app

### DIFF
--- a/R/plot_spatial_fss.R
+++ b/R/plot_spatial_fss.R
@@ -115,7 +115,7 @@ plot_spatial_fss <- function(
   } else {
     if (plot_diff) {
       score <- "fss_diff"
-      score_name <- "FSS diff"
+      score_name <- paste0(score_name," diff")
     } else {
       score <- "fss"
     }

--- a/R/plot_spatial_fss.R
+++ b/R/plot_spatial_fss.R
@@ -51,6 +51,8 @@ plot_spatial_fss <- function(
   ### calculate mean of every threshold/scale pair
   plot_data <- plot_data %>%
                dplyr::group_by(model, prm, threshold, scale) %>%
+               dplyr::mutate(num_cases = n()) %>%
+               dplyr::group_by(model, prm, threshold, scale, num_cases) %>%
                dplyr::summarize_at("fss", mean, na.rm = TRUE)
   
   pt <- paste0(unique(plot_data$model),collapse=",")
@@ -66,16 +68,15 @@ plot_spatial_fss <- function(
     
     if (plot_diff) {
       ref_data  <- plot_data %>% dplyr::filter(model == ref_model) %>%
-        dplyr::mutate(fss_ref = fss) %>% dplyr::ungroup() %>% 
-        dplyr::select(-model,-fss)
+        dplyr::mutate(fss_ref = fss, num_cases_ref = num_cases) %>% dplyr::ungroup() %>% 
+        dplyr::select(-model,-fss,-num_cases)
       plot_data <- plot_data %>% dplyr::filter(model != ref_model)
       plot_data <- dplyr::inner_join(plot_data,
                                      ref_data,
-                                     by=setdiff(names(plot_data),c("fss","model")),
+                                     by=setdiff(names(plot_data),c("fss","model","num_cases")),
                                      relationship = "many-to-many") %>% 
-        dplyr::mutate(fss_diff = fss - fss_ref)
-      score_name <- "FSS Diff"
-      score <- "fss_diff"
+        dplyr::mutate(fss_diff = fss - fss_ref,
+                      num_cases_diff = num_cases - num_cases_ref)
       c_low <- "red"
       c_mid <- "white"
       c_hig <- "blue"
@@ -84,7 +85,6 @@ plot_spatial_fss <- function(
       pt    <- paste0(paste0(unique(plot_data$model),collapse=","),
                       " compared to ",ref_model)
     } else {
-      score <- "fss"
       c_low <- "red"
       c_mid <- "yellow"
       c_hig <- "darkgreen"
@@ -93,14 +93,44 @@ plot_spatial_fss <- function(
     }
   }
   
+  if (score_name == "num_cases") {
+    if (plot_diff) {
+      score <- "num_cases_diff"
+      score_name <- "FSS cases diff"
+    } else {
+      score <- "num_cases"
+      score_name <- "FSS cases"
+    }
+    c_lim <- c(NA,NA)
+    tl    <- "%1.0f"
+    ts    <- 4
+    # Check if number of cases is constant for each forecast model
+    # If so, just filter to one scale for readability
+    qwe <- plot_data %>% 
+      group_by(model, prm, threshold, scale) %>% 
+      summarise(nu = length(unique(num_cases)))
+    if (length(unique(qwe$nu)) <= length(unique(qwe$model))) {
+      plot_data <- plot_data %>% ungroup("scale") %>% filter(scale == min(scale))
+    }
+  } else {
+    if (plot_diff) {
+      score <- "fss_diff"
+      score_name <- "FSS diff"
+    } else {
+      score <- "fss"
+    }
+    tl <- "%1.2f"
+    ts <- 4
+  }
+  
   if (plot_type == "area") {
         gg <- ggplot2::ggplot(plot_data, aes(x = as.factor(get(x_data)),
                                              y = as.factor(get(y_data)),
                                              fill = get(score),
-                                             label = sprintf("%1.2f", get(score)))) +
+                                             label = sprintf(tl, get(score)))) +
               ggplot2::geom_tile() +
               ggplot2::geom_text(colour = "black",
-                                 size   = 4) +
+                                 size   = ts) +
               ggplot2::scale_fill_gradient2(low      = c_low,
                                             mid      = c_mid,
                                             high     = c_hig,

--- a/R/plot_spatial_verif.R
+++ b/R/plot_spatial_verif.R
@@ -132,7 +132,7 @@ plot_spatial_verif <- function(
     savebdate <- strftime(min(plot_data$fcdate, na.rm = TRUE), format = "%Y%m%d%H%M")
     saveedate <- strftime(max(plot_data$fcdate, na.rm = TRUE), format = "%Y%m%d%H%M")
 
-    valid_hours <- unique(lubridate::hour(plot_data$fcdate))
+    valid_hours <- unique(lubridate::hour(plot_data$fcdate)) %>% sort()
   }
 
   # leadtimes in the dataframe are usually in seconds,
@@ -179,7 +179,7 @@ plot_spatial_verif <- function(
   
   # Add in filtered valid hours
   if ("fcst_cycle" %in% names(plot_data)){
-    filtered_valid_hours <- as.integer(unique(plot_data$fcst_cycle))
+    filtered_valid_hours <- as.integer(unique(plot_data$fcst_cycle)) %>% sort()
   } else {
     filtered_valid_hours <- valid_hours
   }

--- a/R/plot_spatial_verif.R
+++ b/R/plot_spatial_verif.R
@@ -31,6 +31,7 @@
 #' @param leadtimes_by Leadtimes in scores are by default expected to be in seconds
 #'   but there is an option to view leadtimes as hours, minutes or seconds.
 #' @param save_image Saves the plot as a .png file without a preset path.
+#' @param plot_num_cases Also plot the number of cases (not available for SAL).
 #' @return A plot (interactive or saved image)
 #' @import ggplot2
 #' @export
@@ -59,6 +60,7 @@ plot_spatial_verif <- function(
   plot_caption      = "auto",
   leadtimes_by      = "hours",
   save_image        = FALSE,
+  plot_num_cases    = FALSE,
 
   ...) {
 
@@ -246,6 +248,26 @@ plot_spatial_verif <- function(
   }
 
   gg <- gg + ggplot2::labs(subtitle = plot_subtitle, caption = plot_caption)
+  
+  if ((plot_num_cases) && 
+      (my_plot_func %in% c("plot_spatial_line","plot_spatial_nact","plot_spatial_fss"))) {
+    num_cases_name <- "num_cases"
+    num_cases_name <- rlang::enquo(num_cases_name)
+    num_cases_name <- rlang::quo_name(num_cases_name)
+    p_nc <- do.call(my_plot_func, c(list(plot_data, num_cases_name), plot_opts))
+    p_nc <- p_nc + theme_func(
+      base_size      = base_size,
+      base_family    = base_family,
+      base_line_size = base_line_size,
+      base_rect_size = base_rect_size
+    )
+    if (my_plot_func == "plot_spatial_fss") {
+      h1 <- 3
+    } else {
+      h1 <- 4
+    }
+    gg <- gridExtra::grid.arrange(gg,p_nc,ncol=1,heights=c(h1,1))
+  }
 
   # finished
   if (save_image) {

--- a/R/plot_spatial_verif.R
+++ b/R/plot_spatial_verif.R
@@ -150,12 +150,17 @@ plot_spatial_verif <- function(
 
   if (filtering) {
     plot_data <- dplyr::filter(plot_data, !!! filter_by)
+    # Apply common cases after filtering
+    plot_data <- spatial_common_cases(plot_data)
     ## forecast dates, find limits again in case it was specified in filtering
     fcbdate <- strftime(min(plot_data$fcdate, na.rm = TRUE), format = "%d-%m-%Y %H:%M")
     fcedate <- strftime(max(plot_data$fcdate, na.rm = TRUE), format = "%d-%m-%Y %H:%M")
     ## filename dates
     savebdate <- strftime(min(plot_data$fcdate, na.rm = TRUE), format = "%Y%m%d%H%M")
     saveedate <- strftime(max(plot_data$fcdate, na.rm = TRUE), format = "%Y%m%d%H%M")
+  } else {
+    # Apply common cases even if no filtering is done
+    plot_data <- spatial_common_cases(plot_data)
   }
 
   # This should be done after filtering

--- a/R/spatial_common_cases.R
+++ b/R/spatial_common_cases.R
@@ -7,7 +7,9 @@
 spatial_common_cases <- function(verif_data) {
   
   # add string of prm_fcdata_leadtime 
-  verif_data <- verif_data %>% dplyr::mutate(ccs = paste(prm,fcdate,leadtime,sep="_"))
+  if (!("ccs" %in% names(verif_data))) {
+    verif_data <- verif_data %>% dplyr::mutate(ccs = paste(prm,fcdate,leadtime,sep="_"))
+  }
   
   # Get ccs common to all models
   ccs_vec <- NULL

--- a/R/spatial_common_cases.R
+++ b/R/spatial_common_cases.R
@@ -1,0 +1,32 @@
+#' Filter spatial scores to common cases only (based on parameter, forecast
+#' start data, and leadtime). Used only as part of \code{plot_spatial_verif}.
+#'
+#' @param verif_data Output from \link[harpSpatial]{spatial_verify}. Must be a 
+#' data frame. 
+
+spatial_common_cases <- function(verif_data) {
+  
+  # add string of prm_fcdata_leadtime 
+  verif_data <- verif_data %>% dplyr::mutate(ccs = paste(prm,fcdate,leadtime,sep="_"))
+  
+  # Get ccs common to all models
+  ccs_vec <- NULL
+  for (cm in unique(verif_data$model)) {
+    ccs <- verif_data %>% dplyr::filter(model == cm) %>% select(ccs)
+    ccs <- unique(ccs$ccs)
+    if (is.null(ccs_vec)) {
+      ccs_vec <- ccs
+    } else {
+      ccs_vec <- base::intersect(ccs_vec,ccs)
+    }
+  }
+  
+  # Then filter to these common ccs
+  verif_data <- verif_data %>% filter(ccs %in% ccs_vec) %>% select(-ccs)
+  
+  if (nrow(verif_data) == 0) {
+    stop("No common data found in spatial data frame")
+  }
+  
+  return(verif_data)
+}

--- a/R/spatial_plot_func.R
+++ b/R/spatial_plot_func.R
@@ -13,8 +13,10 @@ spatial_plot_func <- function(
         "bias"   = "plot_spatial_line",
         "mse"    = "plot_spatial_line",
         "mae"    = "plot_spatial_line",
+        "rmse"   = "plot_spatial_line",
         "SAL"    = "plot_spatial_sal",
         "FSS"    = "plot_spatial_fss",
+        "FSSp"   = "plot_spatial_fss",
         "NACT"   = "plot_spatial_nact",
         "hira_me"    = "plot_spatial_nact",
         #"hira_pragm" = "plot_spatial_fss", #TODO: coming soon

--- a/inst/shiny_apps/plot_spatial_verif/server.R
+++ b/inst/shiny_apps/plot_spatial_verif/server.R
@@ -36,7 +36,7 @@ read_sql <- function(filepath){
 update_options <- function(input,scores,session,st_only=F) {
     #TODO: this function might need a more appropriate name
     if (!st_only) {
-    dates  <- unique(input$dates)
+    dates  <- unique(input$dates) %>% sort()
     cycles <- sort(unique(input$fcst_cycle))
     models <- sort(unique(input$model))
     ref_models <- c("NA",models)

--- a/inst/shiny_apps/plot_spatial_verif/ui.R
+++ b/inst/shiny_apps/plot_spatial_verif/ui.R
@@ -100,7 +100,7 @@ ui <- shiny::tags$html(
                 ),
                 # Allow for a selection of scales/thresholds for NACT and FSS
                 conditionalPanel(
-                  condition = "input.score == 'NACT' || input.score == 'FSS'",
+                  condition = "input.score == 'NACT' || input.score == 'FSS' || input.score == 'FSSp'",
                   selectInput("scales", "Scales",
                               choices = list("NA" = 1),
                               selected = 1,
@@ -121,7 +121,7 @@ ui <- shiny::tags$html(
                             multiple = TRUE),
             
                 conditionalPanel(
-                  condition = "input.score == 'FSS'",
+                  condition = "input.score == 'FSS' || input.score == 'FSSp'",
                   selectInput("ref_model", "Reference model",
                               choices = list("NA" = 1),
                               selected = 1,

--- a/inst/shiny_apps/plot_spatial_verif/ui.R
+++ b/inst/shiny_apps/plot_spatial_verif/ui.R
@@ -84,6 +84,32 @@ ui <- shiny::tags$html(
                 selectInput("score", "Select score",
                               choices = list("NA" = 1),
                                         selected = 1),
+                # Allow for a selection of NACT scores
+                conditionalPanel(
+                  condition = "input.score == 'NACT'",
+                  selectInput("nact_score", "NACT score",
+                              choices = list("All" = "all",
+                                             "Freq bias" = "fbias",
+                                             "POD"  = "pod",
+                                             "FAR"  = "far",
+                                             "PSS"  = "pss",
+                                             "HSS"  = "hss",
+                                             "SEDI" = "sedi"),
+                              selected = "all",
+                              multiple = TRUE),
+                ),
+                # Allow for a selection of scales/thresholds for NACT and FSS
+                conditionalPanel(
+                  condition = "input.score == 'NACT' || input.score == 'FSS'",
+                  selectInput("scales", "Scales",
+                              choices = list("NA" = 1),
+                              selected = 1,
+                              multiple = TRUE),
+                  selectInput("thresholds", "Thresholds",
+                              choices = list("NA" = 1),
+                              selected = 1,
+                              multiple = TRUE),
+                ),
 
                 # Input: Select a daterange
                 dateRangeInput("dates","Date range"),
@@ -118,6 +144,9 @@ ui <- shiny::tags$html(
                 selectInput("param", "Select parameter",
                               choices = list("NA" = 1),
                                         selected = 1),
+            
+                # Input: Show num cases if applicable
+                checkboxInput("showcases","Show number of cases",FALSE),
 
                 # Input: Plot/Show data using selections above
                 actionButton("showdata","Show Data")
@@ -128,7 +157,7 @@ ui <- shiny::tags$html(
         mainPanel(
         # Output: Data file ----
           tabsetPanel(id = "tab_panel",
-                        tabPanel("Plot", plotOutput("plot")),
+                        tabPanel("Plot", uiOutput("plot.ui")),
                         tabPanel("Table", DT::dataTableOutput("table")),
           )
         ) # end of main panel

--- a/inst/shiny_apps/plot_spatial_verif/ui.R
+++ b/inst/shiny_apps/plot_spatial_verif/ui.R
@@ -71,14 +71,14 @@ ui <- shiny::tags$html(
 
     		    # Input: Select a file ----
     		    shiny::uiOutput("frt"),
-            
+    		    
+      		  # Indicate what file is chosen
+      		  br(),
+      		  h5(shinycssloaders::withSpinner(shiny::textOutput("inputfile"))),
+      		  br(),
+  
             conditionalPanel(
             condition = "output.fileUploaded != 0",
-            
-                # Indicate what file is chosen
-                br(),
-                h5(shiny::textOutput("inputfile")),
-                br(),
             
                 # Input: Select score
                 selectInput("score", "Select score",


### PR DESCRIPTION
Some additions based on UWC-W experience:

- Filter to common cases between models (based on parameter, forecast start date, and leadtime) when plotting spatial scores. Currently this is not done in plot_spatial_verif, which can result in misleading behaviour.
- Allow for the number of cases used to be plotted for FSS, NACT, and bias etc.. This is a useful sanity check. The implementation may not be optimal but is quite lightweight. 
- Add more filtering options to the UI i.e. scales, thresholds, NACT score.
- Add a rough method to change the figure size based on selected options.

Tagging in @andrew-MET and @ahtom for review. I can add some figures demonstrating functionality if required. 